### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: softprops/action-gh-release@v1
         with:
           files: |
-            {{ env.APP_NAME }}.zip
+            ${{ env.APP_NAME }}.zip
           tag_name: ${{ steps.tag.outputs.version }}
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
![CleanShot 2023-12-28 at 21 32 27](https://github.com/fohte/mastodon-jihou-bot/assets/11088009/061cf28c-98c0-4bc1-9dcc-18516e19a40d)

```
🤔 Pattern '{{ env.APP_NAME }}.zip' does not match any files.
👩‍🏭 Creating new GitHub release for tag v0.0.3...
🤔 {{ env.APP_NAME }}.zip not include valid file.
🎉 Release ready at https://github.com/fohte/mastodon-jihou-bot/releases/tag/v0.0.3
```

https://github.com/fohte/mastodon-jihou-bot/actions/runs/7347616730/job/20004343749