### PR TITLE
ci: mint GitHub App tokens via octo-sts

### DIFF
--- a/.github/workflows/bumpr.yml
+++ b/.github/workflows/bumpr.yml
@@ -7,20 +7,25 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: mastodon-jihou-bot-bumpr
+          domain: octo-sts.fohte.net
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - uses: haya14busa/action-bumpr@v1
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,19 +3,24 @@ name: Test
 on:
   push:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: mastodon-jihou-bot-test
+          domain: octo-sts.fohte.net
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - uses: actions/setup-go@v5
         with:

--- a/mock_main/mock_service.go
+++ b/mock_main/mock_service.go
@@ -21,6 +21,7 @@ import (
 type MockMastodonService struct {
 	ctrl     *gomock.Controller
 	recorder *MockMastodonServiceMockRecorder
+	isgomock struct{}
 }
 
 // MockMastodonServiceMockRecorder is the mock recorder for MockMastodonService.

--- a/mock_main/mock_time_provider.go
+++ b/mock_main/mock_time_provider.go
@@ -20,6 +20,7 @@ import (
 type MockTimeProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockTimeProviderMockRecorder
+	isgomock struct{}
 }
 
 // MockTimeProviderMockRecorder is the mock recorder for MockTimeProvider.


### PR DESCRIPTION
## Why

- Stop keeping a long-lived GitHub App private key as an Actions secret

## What

- Tokens issued to the workflows now live only for the job's duration, narrowing the blast radius of any leak
    - The matching OrgTrustPolicies are already in place at [`mastodon-jihou-bot-bumpr.sts.yaml`](https://github.com/fohte/.github/blob/43322d3ab16118aa0a756aca4b37ce9697d0ae0b/.github/chainguard/mastodon-jihou-bot-bumpr.sts.yaml) and [`mastodon-jihou-bot-test.sts.yaml`](https://github.com/fohte/.github/blob/43322d3ab16118aa0a756aca4b37ce9697d0ae0b/.github/chainguard/mastodon-jihou-bot-test.sts.yaml)
